### PR TITLE
Fix Unnecessary Effects Running

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-leaflet-geoman-v2",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "React wrapper for the leaflet-geoman plugin",
   "repository": "https://github.com/TurtIeSocks/react-leaflet-geoman",
   "author": "TurtIeSocks <58572875+TurtIeSocks@users.noreply.github.com>",
@@ -16,6 +16,9 @@
     "build": "vite build",
     "build:ts": "tsc --project tsconfig.build.json"
   },
+  "dependencies": {
+    "use-deep-compare-effect": "^1.8.1"
+  },
   "devDependencies": {
     "@geoman-io/leaflet-geoman-free": "^2.13.0",
     "@rollup/plugin-typescript": "^8.4.0",
@@ -30,7 +33,6 @@
     "react-dom": "^18.2.0",
     "react-leaflet": "^4.0.2",
     "typescript": "^4.6.3",
-    "use-deep-compare-effect": "^1.8.1",
     "vite": "^3.0.8",
     "vite-plugin-checker": "^0.4.9"
   },

--- a/src/GeomanControls.ts
+++ b/src/GeomanControls.ts
@@ -20,6 +20,9 @@ export default function GeomanControls({
   ...handlers
 }: GeomanProps): null {
   const [mounted, setMounted] = useState(false)
+  const [handlersRef, setHandlersRef] = useState<Record<string, Function>>(
+    process.env.NODE_ENV === 'development' ? handlers : {}
+  )
   const { map, layerContainer } = useLeafletContext()
   const container = (layerContainer as LayerGroup) || map
 
@@ -61,8 +64,14 @@ export default function GeomanControls({
       globalEvents(map, withDebug, 'off')
       mapEvents(map, withDebug, 'off')
       layers.forEach((layer) => layerEvents(layer, withDebug, 'off'))
+      if (process.env.NODE_ENV === 'development') setHandlersRef(handlers)
     }
-  }, [mounted, Object.values(handlers).every((h) => !h)])
+  }, [
+    mounted,
+    process.env.NODE_ENV === 'development'
+      ? Object.entries(handlers).every(([k, fn]) => handlersRef[k] === fn)
+      : true,
+  ])
 
   return null
 }


### PR DESCRIPTION
- Go back to useDeepEffect to control renders
- Get rid of the useMemo and just add `withDebug` const into the useEffect scope
- Dry up some layers code
- Fix state refreshing when `process.env.NODE_ENV` is in development and handlers are updated
- Version bump