### PR TITLE
refactor: remove use-deep-compare-effect

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-leaflet-geoman-v2",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "React wrapper for the leaflet-geoman plugin",
   "repository": "https://github.com/TurtIeSocks/react-leaflet-geoman",
   "author": "TurtIeSocks <58572875+TurtIeSocks@users.noreply.github.com>",
@@ -15,9 +15,6 @@
     "start": "vite",
     "build": "vite build",
     "build:ts": "tsc --project tsconfig.build.json"
-  },
-  "dependencies": {
-    "use-deep-compare-effect": "^1.8.1"
   },
   "devDependencies": {
     "@geoman-io/leaflet-geoman-free": "^2.14.2",
@@ -40,6 +37,6 @@
     "@geoman-io/leaflet-geoman-free": "^2.14.2",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0",
-    "react-leaflet": "^4.0.2"
+    "react-leaflet": "^4"
   }
 }

--- a/src/GeomanControls.ts
+++ b/src/GeomanControls.ts
@@ -2,7 +2,6 @@ import '@geoman-io/leaflet-geoman-free'
 import { useLayoutEffect, useEffect, useState } from 'react'
 import { useLeafletContext } from '@react-leaflet/core'
 import type { LayerGroup } from 'leaflet'
-import useDeepCompareEffect from 'use-deep-compare-effect'
 
 import type { GeomanProps } from './types'
 import { reference, layerEvents, globalEvents, mapEvents } from './events'
@@ -56,7 +55,7 @@ export default function GeomanControls({
     if (mounted) map.pm.setPathOptions(pathOptions)
   }, [pathOptions, mounted])
 
-  useDeepCompareEffect(() => {
+  useEffect(() => {
     // set global options
     if (mounted)
       map.pm.setGlobalOptions({ layerGroup: container, ...globalOptions })

--- a/yarn.lock
+++ b/yarn.lock
@@ -206,13 +206,6 @@
     "@babel/plugin-syntax-jsx" "^7.18.6"
     "@babel/types" "^7.18.10"
 
-"@babel/runtime@^7.12.5":
-  version "7.18.9"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.9.tgz#b4fcfce55db3d2e5e080d2490f608a3b9f407f4a"
-  integrity sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==
-  dependencies:
-    regenerator-runtime "^0.13.4"
-
 "@babel/template@^7.18.10", "@babel/template@^7.18.6":
   version "7.18.10"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.18.10.tgz#6f9134835970d1dbf0835c0d100c9f38de0c5e71"
@@ -722,11 +715,6 @@ debug@^4.1.0:
   dependencies:
     ms "2.1.2"
 
-dequal@^2.0.2:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.3.tgz#2644214f1997d39ed0ee0ece72335490a7ac67be"
-  integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
-
 electron-to-chromium@^1.4.202:
   version "1.4.233"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.233.tgz#aa142e45468bda111b88abc9cc59d573b75d6a60"
@@ -1180,11 +1168,6 @@ readdirp@~3.6.0:
   dependencies:
     picomatch "^2.2.1"
 
-regenerator-runtime@^0.13.4:
-  version "0.13.9"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz#8925742a98ffd90814988d7566ad30ca3b263b52"
-  integrity sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==
-
 resolve@^1.17.0, resolve@^1.22.1:
   version "1.22.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.1.tgz#27cb2ebb53f91abb49470a928bba7558066ac177"
@@ -1312,14 +1295,6 @@ update-browserslist-db@^1.0.5:
   dependencies:
     escalade "^3.1.1"
     picocolors "^1.0.0"
-
-use-deep-compare-effect@^1.8.1:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/use-deep-compare-effect/-/use-deep-compare-effect-1.8.1.tgz#ef0ce3b3271edb801da1ec23bf0754ef4189d0c6"
-  integrity sha512-kbeNVZ9Zkc0RFGpfMN3MNfaKNvcLNyxOAAd9O4CBZ+kCBXXscn9s/4I+8ytUER4RDpEYs5+O6Rs4PqiZ+rHr5Q==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-    dequal "^2.0.2"
 
 vite-plugin-checker@^0.4.9:
   version "0.4.9"


### PR DESCRIPTION
- Removes `use-deep-compare-effect` as a dependency, this was unnecessary to have
- Loosens the peer dependency of `react-leaflet`
- Patch version bump

Resolves #9 